### PR TITLE
Update to v6.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@
 
 ## <a id="this-plugin-is-built-for"> This plugin is built for
 
-- iOS AppsFlyerSDK **v6.3.2**
-- Android AppsFlyerSDK **v6.2.3**
+- iOS AppsFlyerSDK **v6.5.4**
+- Android AppsFlyerSDK **v6.5.4**
+
+## <a id="breaking-changes"> Breaking Changes
+
+**v6.5.4**
+
+Android: deepLinkResult will return an object instead of a string
 
 ## <a id="installation"> Installation
 

--- a/appsflyer.android.ts
+++ b/appsflyer.android.ts
@@ -111,18 +111,18 @@ export const initSdk = function (args: InitSDKOptions) {
                       _onDeepLinkingCallback: args.onDeepLinking,
                       onDeepLinking(deepLinkResult: Object): void {
                         printLogs(`DeepLinkResult: ${deepLinkResult.toString()}`);
-                        this._onDeepLinkingCallback(deepLinkResult.toString());
+                        this._onDeepLinkingCallback(deepLinkResult);
                       }
                     }));
                   } catch(e){
                     printLogs(`onDeepLinking Error: ${e}`);
                   }
                 }
-
+                
                 appsFlyerLibInstance.init(args.devKey,_appsFlyerConversionListener,(Application.android.context || (<any>com).tns.NativeScriptApplication.getInstance()));
-
+                
                 _start(appsFlyerLibInstance);
-
+                
                 appsFlyerLibInstance.start((<any>com).tns.NativeScriptApplication.getInstance());
 
                 resolve({status: "success"});

--- a/demoNative/app/custom-app-delegate.ios.ts
+++ b/demoNative/app/custom-app-delegate.ios.ts
@@ -2,14 +2,12 @@
 export class CustomAppDelegate extends UIResponder implements UIApplicationDelegate{
     public static ObjCProtocols = [UIApplicationDelegate];
 
-    applicationDidFinishLaunchingWithOptions(application: UIApplication, launchOptions: NSDictionary): boolean {
-        if (parseFloat(UIDevice.currentDevice.systemVersion) >= 14) {
+    applicationDidBecomeActive(application: UIApplication): void {
+        if(parseFloat(UIDevice.currentDevice.systemVersion) >= 14){
             console.log("iOS 14");
             ATTrackingManager.requestTrackingAuthorizationWithCompletionHandler((status) => {
-
             });
         }
-        console.log("applicationDidFinishLaunchingWithOptions");
     }
 
     applicationOpenURLOptions(application: UIApplication, urlOptions: NSURL, options: NSDictionary<string, any>): boolean {

--- a/demoNative/app/main-view-model.js
+++ b/demoNative/app/main-view-model.js
@@ -14,7 +14,7 @@ function createViewModel() {
             devKey: 'WdpTVAcYwmxsaQ4WeTspmh',
             appId: "975313579",
             isDebug: true,
-            timeToWaitForATTUserAuthorization: 60,
+            timeToWaitForATTUserAuthorization: 0,
             onConversionDataSuccess: function (_res) {
                 console.log("Get conversion data success: " + JSON.stringify(_res));
                 viewModel.set("gcdResponse", JSON.stringify(_res));
@@ -30,7 +30,7 @@ function createViewModel() {
                 console.log("onAppOpenAttributionFailure: " + JSON.stringify(_res));
             },
             onDeepLinking: function (_res) {
-                console.log("onDeepLinking: " + _res);
+                console.log("onDeepLinking: " + JSON.parse(_res).deepLink);
             },
         };
         appsFlyer.initSdk(options).then(function (result) {

--- a/demoNative/app/main-view-model.ts
+++ b/demoNative/app/main-view-model.ts
@@ -37,7 +37,7 @@ function createViewModel() {
                 console.log("onAppOpenAttributionFailure: " + JSON.stringify(_res));
             },
             onDeepLinking: function(_res){
-                console.log("onDeepLinking: " + _res);
+                console.log("onDeepLinking: " + JSON.parse(_res).deepLink);
             },
         };
 

--- a/demoNative/package.json
+++ b/demoNative/package.json
@@ -16,7 +16,7 @@
     "@nativescript/core": "~7.0.0",
     "@nativescript/types": "~7.0.0",
     "@nativescript/webpack": "~3.0.0",
-    "tns-ios": "6.5.3",
+    "tns-ios": "6.5.5",
     "ts-patch": "~1.3.3",
     "typescript": "~3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-plugin-appsflyer",
-  "version": "6.3.2-1",
+  "version": "6.5.4",
   "description": "Appsflyer SDK for NativeScript applications",
   "main": "appsflyer",
   "typings": "index.d.ts",

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -14,8 +14,8 @@ def safeExtGet(prop, fallback) {
 }
 dependencies {
 	def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', '16.+')
-	compile "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
-  compile "com.google.android.gms:play-services-identity:$googlePlayServicesVersion"
-  compile "com.android.installreferrer:installreferrer:${safeExtGet('installreferrer', '1.1.2')}"
-  compile "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', "6.2.3")}"
+	implementation "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
+  implementation "com.google.android.gms:play-services-identity:$googlePlayServicesVersion"
+  implementation "com.android.installreferrer:installreferrer:${safeExtGet('installreferrer', '1.1.2')}"
+  implementation "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', "6.5.4")}"
 }

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'AppsFlyerFramework', '~> 6.3.2'
+pod 'AppsFlyerFramework', '~> 6.5.4'


### PR DESCRIPTION
- update to v6.5.4 of ios & android sdk 
- fix init bug on android
- fix iOS life-cycle for att consent dialog
- change deepLinkResult to return object
- update ios run time to v6.5.5 to fix newest macos version bug