### PR TITLE
`getAppsFlyerUID` exposed in API

### DIFF
--- a/appsflyer.android.ts
+++ b/appsflyer.android.ts
@@ -217,6 +217,21 @@ export const setCustomerUserId = function (userId: string) {
     });
 };
 
+export const getAppsFlyerUID = function() {
+    return new Promise(function (resolve, reject) {
+        try {
+            const appsFlyerLibInstance = com.appsflyer.AppsFlyerLib.getInstance();
+            const c = Application.android.context || (<any>com).tns.NativeScriptApplication.getInstance();
+            const uid = appsFlyerLibInstance.getAppsFlyerUID(c);
+
+            resolve(uid);
+        } catch (ex) {
+            printLogs("setCustomerUserId Error: " + ex);
+            reject(ex);
+        }
+    });
+}
+
 export const setSharingFilter = function (partners: Array<string>) {
 
   return new Promise(function (resolve, reject) {

--- a/appsflyer.ios.ts
+++ b/appsflyer.ios.ts
@@ -119,6 +119,24 @@ export const setCustomerUserId = function (userId: string) {
     });
 };
 
+export const getAppsFlyerUID = function() {
+    return new Promise((resolve, reject) => {
+        try {
+
+            if (typeof(AppsFlyerLib) !== "undefined") {
+                const uid = AppsFlyerLib.shared().getAppsFlyerUID();
+                resolve(uid);
+            } else {
+                reject({status: "failure", message: "AppsFlyer is not defined, call 1st 'initSdk'"});
+            }
+
+        } catch (ex) {
+            console.log("AF_IOS ::  Error: " + ex);
+            reject(ex);
+        }
+    });
+}
+
 @NativeClass
 class DeepLinkDelegate extends NSObject implements AppsFlyerDeepLinkDelegate {
     public static ObjCProtocols = [AppsFlyerDeepLinkDelegate];

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export function setSharingFilterForAllPartners(): Promise<{status} | any>;
 
 export function setCustomerUserId (userId: string): Promise<{status} | any>;
 
-
+export function getAppsFlyerUID(): Promise<string>;
 
 export interface ConversionData {
   af_status;


### PR DESCRIPTION
This PR exposes the `getAppsFlyerUID` API from the native SDKs in the Nativescript plugin API.