### PR TITLE
Privacy Manifest and version bump

### DIFF
--- a/.migration_backup/package.json
+++ b/.migration_backup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-plugin-appsflyer",
-  "version": "6.13.1",
+  "version": "6.14.3",
   "description": "Appsflyer SDK for NativeScript applications",
   "main": "appsflyer",
   "typings": "index.d.ts",

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@
 
 ## <a id="this-plugin-is-built-for"> This plugin is built for
 
-- iOS AppsFlyerSDK **v6.13.1**
-- Android AppsFlyerSDK **v6.13.0**
+- iOS AppsFlyerSDK **v6.14.3**
+- Android AppsFlyerSDK **v6.14.0**
 
 ## <a id="breaking-changes"> Breaking Changes
+
+**v6.14.3**
+
+iOS Minimum deployment target: 12 , Android minSdk: 19 
 
 **v6.5.4**
 
@@ -34,7 +38,8 @@ Android: deepLinkResult will return an object instead of a string
 
 `$ tns plugin add nativescript-plugin-appsflyer`
 
-
+### Huawei Referrer (Android)
+Huawei Referrer is supported in SDK v6.14.0 and above. Due to changes in the Huawei AppGallery store, previous versions of the AppsFlyer SDK are not able to fetch the referrer from the store. Learn more.
 
 ## <a id="Integration">  Integration
 

--- a/appsflyer.android.ts
+++ b/appsflyer.android.ts
@@ -141,7 +141,7 @@ const initSdk = function (args: InitSDKOptions) {
         const platform_extension = com.appsflyer.internal.platform_extension;
         const pluginInfoClass = new platform_extension.PluginInfo(
           platform_extension.Plugin.NATIVE_SCRIPT,
-          "6.13.1",
+          "6.14.3",
           new java.util.HashMap()
         );
         appsFlyerLibInstance.setPluginInfo(pluginInfoClass);

--- a/appsflyer.ios.ts
+++ b/appsflyer.ios.ts
@@ -65,7 +65,7 @@ const initSdk = function (args: InitSDKOptions) {
 
         AppsFlyerLib.shared().setPluginInfoWithPluginVersionAdditionalParams(
           AFSDKPlugin.AFSDKPluginNativeScript,
-          "6.13.1",
+          "6.14.3",
           null
         );
         

--- a/demoNative/App_Resources/Android/app.gradle
+++ b/demoNative/App_Resources/Android/app.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     multiDexEnabled true
-    minSdkVersion 17
+    minSdkVersion 19
     // targetSdkVersion 32
 
     // Version Information

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-plugin-appsflyer",
-  "version": "6.13.1",
+  "version": "6.14.3",
   "description": "Appsflyer SDK for NativeScript applications",
   "main": "appsflyer",
   "typings": "index.d.ts",

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -14,5 +14,5 @@ def safeExtGet(prop, fallback) {
 }
 dependencies {
   implementation "com.android.installreferrer:installreferrer:${safeExtGet('installreferrer', '2.2')}"
-  implementation "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', "6.13.0")}"
+  implementation "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', "6.14.0")}"
 }

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'AppsFlyerFramework', '~> 6.13.1'
+pod 'AppsFlyerFramework', '~> 6.14.3'


### PR DESCRIPTION
- Updated Android to v6.14.0 and iOS to v6.14.3
- Added privacy manifest according to Apple , Privacy report example:
[demoNative-PrivacyReport 2024-05-07 11-03-34.pdf](https://github.com/AppsFlyerSDK/appsflyer-nativescript-plugin/files/15232568/demoNative-PrivacyReport.2024-05-07.11-03-34.pdf)
